### PR TITLE
Allow assembly loading as long as the main application has permission to run.

### DIFF
--- a/main/src/core/MonoDevelop.Startup/app.config
+++ b/main/src/core/MonoDevelop.Startup/app.config
@@ -7,6 +7,7 @@
 				<bindingRedirect oldVersion="0.84.0.0" newVersion="2.84.0.0"/>
 			</dependentAssembly>
 		</assemblyBinding>
+		<loadFromRemoteSources enabled="true" />
 	</runtime>
 	
 	<!-- This is required by the subversion add-in for windows, which uses a mixed mode assembly built with .NET 2.0 -->


### PR DESCRIPTION
Allow assembly loading as long as the main application has permission to run.
Prevents mysterious exit-on-start on windows.
See http://msdn.microsoft.com/en-us/library/dd409252.aspx
