### PR TITLE
Unity-specific workarounds for reproducible cases of completion breakage

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/Ide.cs
@@ -342,10 +342,8 @@ namespace MonoDevelop.Ide
 				}
 			}
 
-			if (!foundSln)
+			if (!(foundSln || Workspace.IsLoading))
 				loadFilteredFiles (null, null);
-			
-
 			
 			Workbench.Present ();
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
@@ -88,6 +88,7 @@ namespace MonoDevelop.Ide
 			
 			// Set the initial active runtime
 			UseDefaultRuntime = true;
+			IsLoading = false;
 			IdeApp.Preferences.DefaultTargetRuntimeChanged += delegate {
 				// If the default runtime changes and current active is default, update it
 				if (UseDefaultRuntime) {
@@ -158,6 +159,13 @@ namespace MonoDevelop.Ide
 		
 		public bool IsOpen {
 			get { return Items.Count > 0; }
+		}
+		
+		// Hackish way of detecting whether a workspace item
+		// is currently being loaded
+		public bool IsLoading {
+			get;
+			protected set;
 		}
 		
 		public CodeRefactorer GetCodeRefactorer (Solution solution) 
@@ -504,6 +512,8 @@ namespace MonoDevelop.Ide
 		
 		public IAsyncOperation OpenWorkspaceItem (string filename, bool closeCurrent, bool loadPreferences)
 		{
+			IsLoading = true;
+			
 			if (closeCurrent) {
 				if (!Close ())
 					return MonoDevelop.Core.ProgressMonitoring.NullAsyncOperation.Failure;
@@ -1206,6 +1216,7 @@ namespace MonoDevelop.Ide
 		
 		void OnItemLoaded (WorkspaceItem item)
 		{
+			IsLoading = false;
 			try {
 				if (WorkspaceItemLoaded != null)
 					WorkspaceItemLoaded (this, new WorkspaceItemEventArgs (item));

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
@@ -916,7 +916,7 @@ namespace MonoDevelop.Ide
 					hasUnsaved = true;
 				if (!doc.IsFile)
 					hasNoFiles = true;
-				ISupportsProjectReload pr = doc.GetContent<ISupportsProjectReload> ();
+				ISupportsProjectReload pr = null; // Don't reload projects in place
 				if (pr != null) {
 					ProjectReloadCapability c = pr.ProjectReloadCapability;
 					if ((int) c < (int) prc)
@@ -936,10 +936,9 @@ namespace MonoDevelop.Ide
 						msg = GettextCatalog.GetString ("WARNING: Some documents may need to be reloaded or closed, and unsaved data will be lost. You will be asked to save the unsaved documents.");
 					else if (hasUnsaved)
 						msg = GettextCatalog.GetString ("WARNING: Some files may need to be reloaded, and unsaved data will be lost. You will be asked to save the unsaved files.");
-					else
-						goto case ProjectReloadCapability.UnsavedData;
+					// Don't force reload confirmation
 					break;
-					
+
 				case ProjectReloadCapability.UnsavedData:
 					msg = GettextCatalog.GetString ("Some files may need to be reloaded, and editing status for those files (such as the undo queue) will be lost.");
 					break;
@@ -954,7 +953,7 @@ namespace MonoDevelop.Ide
 			foreach (Document doc in docs) {
 				if (doc.IsDirty)
 					hasUnsaved = true;
-				ISupportsProjectReload pr = doc.GetContent<ISupportsProjectReload> ();
+				ISupportsProjectReload pr = null; // Don't reload projects in place
 				if (pr != null)
 					doc.SetProject (null);
 				else {


### PR DESCRIPTION
- Reloading projects in-place and breaking source<=>completionDom linkages
- A source file being opened before its project has finished loading
