### PR TITLE
MD fixes

### DIFF
--- a/main/src/addins/MacPlatform/MacInterop/GtkQuartz.cs
+++ b/main/src/addins/MacPlatform/MacInterop/GtkQuartz.cs
@@ -27,6 +27,8 @@
 using System;
 using System.Runtime.InteropServices;
 using MonoMac.AppKit;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace MonoDevelop.MacInterop
 {
@@ -41,6 +43,24 @@ namespace MonoDevelop.MacInterop
 			var window = GetWindow (widget);
 			if (window != null)
 				window.MakeKeyAndOrderFront (window);
+		}
+
+		public static Gtk.Window GetGtkWindow (NSWindow window)
+		{
+			var toplevels = Gtk.Window.ListToplevels ();
+			return toplevels.FirstOrDefault (w => gdk_quartz_window_get_nswindow (w.GdkWindow.Handle) == window.Handle);
+		}
+
+		public static IEnumerable<KeyValuePair<NSWindow,Gtk.Window>> GetToplevels ()
+		{
+			var nsWindows = NSApplication.SharedApplication.Windows;
+			var gtkWindows = Gtk.Window.ListToplevels ();
+			foreach (var n in nsWindows) {
+				var g = gtkWindows.FirstOrDefault (w => {
+					return w.GdkWindow != null && gdk_quartz_window_get_nswindow (w.GdkWindow.Handle) == n.Handle;
+				});
+				yield return new KeyValuePair<NSWindow, Gtk.Window> (n, g);
+			}
 		}
 		
 		public static NSWindow GetWindow (Gtk.Window window)

--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -55,19 +55,24 @@ namespace MonoDevelop.MacIntegration
 	{
 		const string monoDownloadUrl = "http://www.go-mono.com/mono-downloads/download.html";
 
-		static TimerCounter timer = InstrumentationService.CreateTimerCounter ("Mac Platform Initialization", "Platform Service");
-		static TimerCounter mimeTimer = InstrumentationService.CreateTimerCounter ("Mac Mime Database", "Platform Service");
+		TimerCounter timer = InstrumentationService.CreateTimerCounter ("Mac Platform Initialization", "Platform Service");
+		TimerCounter mimeTimer = InstrumentationService.CreateTimerCounter ("Mac Mime Database", "Platform Service");
+
+		static bool initedGlobal;
+		bool setupFail, initedApp;
 		
-		static bool setupFail, initedApp, initedGlobal;
-		
-		static Lazy<Dictionary<string, string>> mimemap;
+		Lazy<Dictionary<string, string>> mimemap;
 		
 		//this is a BCD value of the form "xxyz", where x = major, y = minor, z = bugfix
 		//eg. 0x1071 = 10.7.1
-		static int systemVersion;
+		int systemVersion;
 
-		static MacPlatformService ()
+		public MacPlatformService ()
 		{
+			if (initedGlobal)
+				throw new Exception ("Only one MacPlatformService instance allowed");
+			initedGlobal = true;
+
 			timer.BeginTiming ();
 			
 			systemVersion = Carbon.Gestalt ("sysv");
@@ -149,7 +154,7 @@ namespace MonoDevelop.MacIntegration
 			get { return "OSX"; }
 		}
 		
-		static Dictionary<string, string> LoadMimeMapAsync ()
+		Dictionary<string, string> LoadMimeMapAsync ()
 		{
 			var map = new Dictionary<string, string> ();
 			// All recent Macs should have this file; if not we'll just die silently
@@ -202,7 +207,7 @@ namespace MonoDevelop.MacIntegration
 			return true;
 		}
 		
-		static void InitApp (CommandManager commandManager)
+		void InitApp (CommandManager commandManager)
 		{
 			if (initedApp)
 				return;
@@ -242,11 +247,8 @@ namespace MonoDevelop.MacIntegration
 			IdeApp.Workbench.RootWindow.DeleteEvent += HandleDeleteEvent;
 		}
 
-		static void GlobalSetup ()
+		void GlobalSetup ()
 		{
-			if (initedGlobal || setupFail)
-				return;
-			initedGlobal = true;
 			
 			//FIXME: should we remove these when finalizing?
 			try {

--- a/main/src/addins/MacPlatform/MacPlatform.cs
+++ b/main/src/addins/MacPlatform/MacPlatform.cs
@@ -249,22 +249,15 @@ namespace MonoDevelop.MacIntegration
 
 		void GlobalSetup ()
 		{
-			
 			//FIXME: should we remove these when finalizing?
 			try {
 				ApplicationEvents.Quit += delegate (object sender, ApplicationQuitEventArgs e)
 				{
-					// Easy case, we're pretty sure a modal dialog isn't running.
-					// All our custom Cocoa dialogs use subclasses, not vanilla NSWindow.
-					// GTK uses NSWindow but we can determine whether it's modal from GTK.
-					var keyWindow = NSApplication.SharedApplication.KeyWindow;
-					if (keyWindow != null && keyWindow.ClassHandle == MonoMac.ObjCRuntime.Class.GetHandle ("NSWindow")) {
-						var windows = Gtk.Window.ListToplevels ();
-						if (!windows.Any (w => w.Modal && w.Visible)) {
-							e.UserCancelled = !IdeApp.Exit ();
-							e.Handled = true;
-							return;
-						}
+					// We can only attempt to quit safely if all windows are GTK windows and not modal
+					if (GtkQuartz.GetToplevels ().All (t => t.Value != null && (!t.Value.Visible || !t.Value.Modal))) {
+						e.UserCancelled = !IdeApp.Exit ();
+						e.Handled = true;
+						return;
 					}
 
 					// When a modal dialog is running, things are much harder. We can't just shut down MD behind the

--- a/main/src/addins/MonoDevelop.Debugger.Soft/Mono.Debugging.Soft/SoftDebuggerSession.cs
+++ b/main/src/addins/MonoDevelop.Debugger.Soft/Mono.Debugging.Soft/SoftDebuggerSession.cs
@@ -1817,6 +1817,9 @@ namespace Mono.Debugging.Soft
 		
 		static string ResolveFullPath (string path)
 		{
+			if (string.IsNullOrEmpty (path))
+				return path;
+
 			if (IsWindows)
 				return Path.GetFullPath (path);
 

--- a/main/src/core/Mono.Debugging/Mono.Debugging.Evaluation/ObjectValueAdaptor.cs
+++ b/main/src/core/Mono.Debugging/Mono.Debugging.Evaluation/ObjectValueAdaptor.cs
@@ -1037,10 +1037,11 @@ namespace Mono.Debugging.Evaluation
 				if (i != -1)
 					ttype = GetType (ctx, data.ProxyType.Substring (0, i).Trim (), typeArgs);
 			}
-			if (ttype == null)
-				throw new EvaluatorException ("Unknown type '{0}'", data.ProxyType);
 
-			try {
+			try
+			{
+				if (ttype == null)
+					throw new EvaluatorException ("Unknown type '{0}'", data.ProxyType);
 				object val = CreateValue (ctx, ttype, obj);
 				return val ?? obj;
 			} catch (Exception ex) {

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
@@ -32,6 +32,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
+using System.Linq;
 
 using Mono.Addins;
 using MonoDevelop.Core;

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Desktop/PlatformService.cs
@@ -427,5 +427,27 @@ namespace MonoDevelop.Ide.Desktop
 		{
 			return new MainToolbar ();
 		}
+
+		public virtual bool GetIsFullscreen (Gtk.Window window)
+		{
+			return ((bool?) window.Data ["isFullScreen"]) ?? false;
+		}
+
+		public virtual bool IsModalDialogRunning ()
+		{
+			var windows = Gtk.Window.ListToplevels ();
+			return windows.Any (w => w.Modal && w.Visible);
+		}
+
+		public virtual void SetIsFullscreen (Gtk.Window window, bool isFullscreen)
+		{
+			window.Data ["isFullScreen"] = isFullscreen;
+			if (isFullscreen) {
+				window.Fullscreen ();
+			} else {
+				window.Unfullscreen ();
+				SetMainWindowDecorations (window);
+			}
+		}
 	}
 }

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -194,15 +194,15 @@ namespace MonoDevelop.Ide.Gui
 		/// </summary>
 		public bool HasToplevelFocus {
 			get {
-				var windows = Gtk.Window.ListToplevels ();
-				if (windows.Any (w => w.Modal && w.Visible))
+				if (DesktopService.IsModalDialogRunning ())
 					return false;
+				var windows = Gtk.Window.ListToplevels ();
 				var toplevel = windows.FirstOrDefault (x => x.HasToplevelFocus);
 				if (toplevel == null)
 					return false;
 				if (toplevel == RootWindow)
 					return true;
-				var dock = toplevel as MonoDevelop.Components.Docking.DockFloatingWindow;
+				var dock = toplevel as DockFloatingWindow;
 				return dock != null && dock.DockParent == RootWindow;
 			}
 		}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/DesktopService.cs
@@ -229,5 +229,20 @@ namespace MonoDevelop.Ide
 		{
 			return PlatformService.CreateMainToolbar (window);
 		}
+
+		public static bool GetIsFullscreen (Gtk.Window window)
+		{
+			return PlatformService.GetIsFullscreen (window);
+		}
+
+		public static void SetIsFullscreen (Gtk.Window window, bool isFullscreen)
+		{
+			PlatformService.SetIsFullscreen (window, isFullscreen);
+		}
+
+		public static bool IsModalDialogRunning ()
+		{
+			return PlatformService.IsModalDialogRunning ();
+		}
 	}
 }


### PR DESCRIPTION
- Don't block shutdown on OSX
- Fall back to raw type inspection when debugger proxy type lookup fails (e.g. inspecting List<T> on .NET)
