### PR TITLE
Fixed issue where the same file could be open twice.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui/Workbench.cs
@@ -928,7 +928,7 @@ namespace MonoDevelop.Ide.Gui
 				
 				foreach (DocumentUserPrefs doc in prefs.Files.Distinct (new DocumentUserPrefsFilenameComparer ())) {
 					string fileName = baseDir.Combine (doc.FileName).FullPath;
-					if (File.Exists (fileName)) {
+					if (GetDocument(fileName) == null && File.Exists (fileName)) {
 						var view = IdeApp.Workbench.BatchOpenDocument (pm, fileName, doc.Line, doc.Column);
 						if (fileName == currentFileName)
 							currentView = view;


### PR DESCRIPTION
If you have a file A open and then open a solution where file A is in
the user preferences, then file A will be opened twice.
