### PR TITLE
Do not hide debug command bar if we are exiting the MonoDevelop

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/DebuggingService.cs
@@ -77,6 +77,8 @@ namespace MonoDevelop.Debugger
 		static bool isBusy;
 		static StatusBarIcon busyStatusIcon;
 
+		static bool IdeExiting = false;
+
 		static public event EventHandler DebugSessionStarted;
 		static public event EventHandler PausedEvent;
 		static public event EventHandler ResumedEvent;
@@ -110,6 +112,8 @@ namespace MonoDevelop.Debugger
 				// Regresh the engine list
 				evaluators = null;
 			});
+
+			IdeApp.Exiting += (object sender, ExitEventArgs args) => IdeExiting = true;
         }
 
 		public static IExecutionHandler GetExecutionHandler ()
@@ -552,6 +556,9 @@ namespace MonoDevelop.Debugger
 
 		static void HideDebugCommandBar (string layout)
 		{
+			if (IdeExiting)
+				return;
+
 			// Dispatch asynchronously to avoid start/stop races
 			DispatchService.GuiSyncDispatch (delegate {
 				IdeApp.Workbench.HideCommandBar ("Debug");


### PR DESCRIPTION
Fix issue with MonoDevelop not closing down properly if the debugger is still attached on shutdown.

Also removing MDMenuItem.cs that was not reverted properly in this commit: https://github.com/Unity-Technologies/monodevelop/commit/6ac03ff58accf22862ba28173c5430d1eee37e28

Which reverted this commit: https://github.com/Unity-Technologies/monodevelop/commit/55fea305d4303d921fd6812f22b4d4b408320e92

Notice there are only 10 files reverted, but 11 in the original commit.
