### PR TITLE
AttachToProcessDialog Fix

### DIFF
--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/AttachToProcessDialog.cs
+++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/AttachToProcessDialog.cs
@@ -51,6 +51,7 @@ namespace MonoDevelop.Debugger
 			tree.Model = store;
 			tree.AppendColumn ("PID", new Gtk.CellRendererText (), "text", 1);
 			tree.AppendColumn ("Process Name", new Gtk.CellRendererText (), "text", 2);
+			tree.RowActivated += OnRowActivated;
 
 			state = new TreeViewState (tree, 1);
 


### PR DESCRIPTION
Call OnRowActivated. Fixes issues with double clicking entries in the process tree view not working.
