### PR TITLE
Remove "Show Error References", "API Documentation" and "Report a bug" menu items

### DIFF
--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
@@ -726,13 +726,14 @@
 	<!-- HelpCommands -->
 	<Category _name = "Help" id = "Help">
 
+	<!---
 	<Command id = "MonoDevelop.Ide.Commands.HelpCommands.Help"
 			_label = "API Documentation"
 			icon = "gtk-help"
 			_description = "Show help"
 			defaultHandler = "MonoDevelop.Ide.Commands.HelpHandler"
 			shortcut = "F1"
-			macShortcut = "Meta|Alt|?" />
+			macShortcut = "Meta|Alt|?" /> -->
 	<Command id = "MonoDevelop.Ide.Commands.HelpCommands.TipOfTheDay"
 			defaultHandler = "MonoDevelop.Ide.Commands.TipOfTheDayHandler"
 			_label = "_Tip of the Day"

--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MainMenu.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MainMenu.addin.xml
@@ -260,7 +260,7 @@
 		</ItemSet>
 		<SeparatorItem id = "Separator3" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.HelpCommands.OpenLogDirectory" />
-		<LinkItem id = "ReportBug" _label = "Report a Bug" link = "http://xamar.in/r/file_studio_bug" />
+<!---	<LinkItem id = "ReportBug" _label = "Report a Bug" link = "http://xamar.in/r/file_studio_bug" /> -->
 		<Condition id = "Platform" value = "!mac">
 			<CommandItem id = "MonoDevelop.Ide.Commands.HelpCommands.About" />
 		</Condition>

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide.Gui.Pads/ErrorListPad.cs
@@ -316,10 +316,10 @@ namespace MonoDevelop.Ide.Gui.Pads
 			
 			var group = new ActionGroup ("Popup");
 
-			var help = new Gtk.Action ("help", GettextCatalog.GetString ("Show Error Reference"),
-				GettextCatalog.GetString ("Show Error Reference"), Gtk.Stock.Help);
-			help.Activated += OnShowReference;
-			group.Add (help, "F1");
+//			var help = new Gtk.Action ("help", GettextCatalog.GetString ("Show Error Reference"),
+//				GettextCatalog.GetString ("Show Error Reference"), Gtk.Stock.Help);
+//			help.Activated += OnShowReference;
+//			group.Add (help, "F1");
 
 			var copy = new Gtk.Action ("copy", GettextCatalog.GetString ("_Copy"),
 				GettextCatalog.GetString ("Copy task"), Gtk.Stock.Copy);
@@ -380,7 +380,7 @@ namespace MonoDevelop.Ide.Gui.Pads
 			uiManager.InsertActionGroup (group, 0);
 			
 			string uiStr = "<ui><popup name='popup'>"
-				+ "<menuitem action='help'/>"
+//				+ "<menuitem action='help'/>"
 				+ "<menuitem action='copy'/>"
 				+ "<menuitem action='jump'/>"
 				+ "<separator/>"
@@ -407,7 +407,8 @@ namespace MonoDevelop.Ide.Gui.Pads
 				columnFile.Active = view.Columns[VisibleColumns.File].Visible;
 				columnProject.Active = view.Columns[VisibleColumns.Project].Visible;
 				columnPath.Active = view.Columns[VisibleColumns.Path].Visible;
-				help.Sensitive = copy.Sensitive = jump.Sensitive =
+				// help.Sensitive = copy.Sensitive = jump.Sensitive =
+				copy.Sensitive = jump.Sensitive =
 					view.Selection != null &&
 					view.Selection.CountSelectedRows () > 0 &&
 					(columnType.Active ||


### PR DESCRIPTION
Removing references to documentation browser, as we do not support/bundle it.
