### PR TITLE
Revert dialog on OSX warning the user about MonoDevelop path containing spaces.

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -221,7 +221,7 @@ namespace MonoDevelop.Ide
 			if (Platform.IsMac && p.FullPath.ToString().Contains(' '))
 			{
 				// Will be fixed once this fix: https://github.com/mono/mono/pull/2062 makes into a OSX Mono framework release and we can update the bundled framework.
-				string message = BrandingService.BrandApplicationName (GettextCatalog.GetString ("Copy MonoDevelop to a path without spaces. This requirement will be fixed in the future."));
+				string message = BrandingService.BrandApplicationName (GettextCatalog.GetString ("Copy MonoDevelop to a path without spaces. This will requirement will be fixed in the future."));
 				MessageService.ShowFatalError (message, "Current path: " + p.ParentDirectory.FullPath, null);
 				return 1;
 			}

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -217,16 +217,6 @@ namespace MonoDevelop.Ide
 			if (Assembly.GetEntryAssembly ().GetName ().Version.Revision != 0)
 				version += "." + Assembly.GetEntryAssembly ().GetName ().Version.Revision;
 
-
-			if (Platform.IsMac && p.FullPath.ToString().Contains(' '))
-			{
-				// Will be fixed once this fix: https://github.com/mono/mono/pull/2062 makes into a OSX Mono framework release and we can update the bundled framework.
-				string message = BrandingService.BrandApplicationName (GettextCatalog.GetString ("Copy MonoDevelop to a path without spaces. This will requirement will be fixed in the future."));
-				MessageService.ShowFatalError (message, "Current path: " + p.ParentDirectory.FullPath, null);
-				return 1;
-			}
-
-
 			CheckFileWatcher ();
 			
 			Exception error = null;


### PR DESCRIPTION
No longer necessary due to this change: https://github.com/Unity-Technologies/monodevelop-build/pull/9
