### PR TITLE
MonoDevelop 5.9 fixes

### DIFF
--- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MainMenu.addin.xml
+++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MainMenu.addin.xml
@@ -241,7 +241,7 @@
 	</ItemSet> 
 
 	<ItemSet id = "Help" _label = "_Help">
-		<CommandItem id = "MonoDevelop.Ide.Commands.HelpCommands.Help" />
+<!--		<CommandItem id = "MonoDevelop.Ide.Commands.HelpCommands.Help" /> -->
 		<CommandItem id = "MonoDevelop.Ide.Commands.HelpCommands.TipOfTheDay" />
 		<CommandItem id = "MonoDevelop.Ide.Commands.HelpCommands.SendFeedback" />
 		<Condition id = "Platform" value = "!mac">

--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
@@ -663,6 +663,26 @@ namespace MonoDevelop.Ide
 						"may not be properly installed in the GAC.",
 						BrandingService.ApplicationName
 					), ex);
+
+				if (Platform.IsWindows)
+				{
+					string url = "http://monodevelop.com/Download";
+					string caption = "Fatal Error";
+					string message =
+						"{0} failed to start. Some of the assemblies required to run {0} (for example GTK#) " +
+						"may not be properly installed in the GAC.\n\r\n\r" +
+						"Please click OK to open the download page, where " +
+						"you can download the necessary dependencies for {0} to run.";
+
+					if (DisplayWindowsOkCancelMessage(
+						string.Format(message, BrandingService.ApplicationName, url), caption)
+					)
+					{
+						Process.Start(url);
+					}
+				}
+
+
 			} finally {
 				Runtime.Shutdown ();
 			}


### PR DESCRIPTION
- Show missing GTK# installation error in native dialog on Windows. Fixes case 735412
- Hide removed "API Reference" (docbrowser) menu item from main "Help" menu.
