### PR TITLE
[ide] Make setters public

### DIFF
--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
@@ -109,7 +109,7 @@ namespace MonoDevelop.Ide
 			get {
 				return currentWorkspaceItem;
 			}
-			internal set {
+			set {
 				if (value != currentWorkspaceItem) {
 					WorkspaceItem oldValue = currentWorkspaceItem;
 					currentWorkspaceItem = value;
@@ -125,7 +125,7 @@ namespace MonoDevelop.Ide
 					return CurrentSelectedSolution.RootFolder;
 				return currentSolutionItem;
 			}
-			internal set {
+			set {
 				if (value != currentSolutionItem) {
 					SolutionItem oldValue = currentSolutionItem;
 					currentSolutionItem = value;
@@ -139,7 +139,7 @@ namespace MonoDevelop.Ide
 			get {
 				return currentItem;
 			}
-			internal set {
+			set {
 				currentItem = value;
 			}
 		}


### PR DESCRIPTION
Make setters public for CurrentSelectedWorkspaceItem, CurrentSelectedSolutionItem & CurrentSelectedItem public. Allows to set active solution and project without solution pad.

Required for MonoDevelop Rest Integration.
