### PR TITLE
[source-editor] Set encoding of view to encoding used for writing.

### DIFF
--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
@@ -712,6 +712,7 @@ namespace MonoDevelop.SourceEditor
 						}
 					}
 					Mono.TextEditor.Utils.TextFileUtility.WriteText (fileName, writeText, writeEncoding, writeBom);
+					this.encoding = writeEncoding;
 				} catch (InvalidEncodingException) {
 					var result = MessageService.AskQuestion (GettextCatalog.GetString ("Can't save file with current codepage."), 
 						GettextCatalog.GetString ("Some unicode characters in this file could not be saved with the current encoding.\nDo you want to resave this file as Unicode ?\nYou can choose another encoding in the 'save as' dialog."),


### PR DESCRIPTION
Fixes issue with text view showing garbage characters (file loaded with wrong encoding) when using "Save As" and saving to a different encoding than the current view is using.

This patch has been accepted upstream: https://github.com/mono/monodevelop/pull/1217
