### PR TITLE
Add another Layer.Sublayers null check

### DIFF
--- a/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
+++ b/main/src/addins/MacPlatform/MainToolbar/StatusBar.cs
@@ -202,6 +202,7 @@ namespace MonoDevelop.MacIntegration.MainToolbar
 					return;
 
 				ReconstructString ();
+				if(Layer.Sublayers != null)
 				foreach (var layer in Layer.Sublayers) {
 					if (layer.Name != null && layer.Name.StartsWith (StatusIconPrefixId, StringComparison.Ordinal))
 						layer.SetImage (layerToStatus [layer.Name].Image, Window.BackingScaleFactor);


### PR DESCRIPTION
Fixes start-up crash macOS 10.13 when using multiple monitors.

Fixes case 955089